### PR TITLE
Claude Code joins the Orchard!

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+A spec-driven development workshop teaching engineers about lightweight formal methods through Java exercises. The core demonstrates JML (Java Modeling Language) specifications, property-based testing, and static analysis on intentionally buggy code.
+
+## Build Commands
+
+All commands go through Make. The default target is `check`.
+
+```bash
+make tooling       # One-time: download JDK 21, OpenJML, Z3 (requires internet)
+make check         # Format → compile (with Errorprone) → SpotBugs → Spotless check → tests
+make check-jml     # check + OpenJML formal verification (extended static checking)
+make test          # Tests only (JUnit 5 + jqwik + Fray via Surefire)
+make format        # Auto-format with Spotless (Palantir style)
+make clean         # Delete build artifacts
+make jshell        # Interactive JShell with full classpath
+make repl          # Clojure REPL with full classpath
+make uberjar       # Fat JAR via maven-shade-plugin
+make run           # Execute the uberjar
+```
+
+To run a single test class: `JAVA_HOME=$(make -s -p | grep '^JHOME' | cut -d= -f2) mvn test -Dtest=AppTest`
+
+## Verification Pipeline
+
+`make check` chains: Spotless format → Errorprone (extended type checking) → SpotBugs + FindSecurityBugs → JUnit 5/jqwik/Fray tests. `make check-jml` adds OpenJML's ESC pass using the Z3 SMT solver against JML annotations in source.
+
+## Code Style
+
+Palantir Java Format (modified Google Style) enforced by Spotless. Run `make format` before committing.
+
+## Architecture
+
+- **Java 21** compiled via project-local JDK in `tooling/jdk-21.0.7+6/`
+- **Maven** (`pom.xml`) manages dependencies and plugins; profiles: `errorprone`, `openjml`, `dev`
+- **`Makefile.preamble`** handles platform detection (Linux/macOS/aarch64), JDK path resolution, and checksum verification
+- Source: `src/main/java/com/kevel/` — application code with inline JML specs (`/*@ ... @*/`)
+- Tests: `src/test/java/com/kevel/` — JUnit 5 unit tests + jqwik property-based tests
+- OpenJML binary: `tooling/openjml/openjml` — invoked directly for `check-jml-only`
+
+## JML Specifications
+
+JML specs live inline in Java source as `/*@ ... @*/` comments. Key constructs: `requires` (preconditions), `ensures` (postconditions), `pure` (no side effects). Use `// @ skipesc skiprac` to exclude methods from verification. OpenJML catches issues like integer overflow that tests may miss.
+
+## Sandboxed Development
+
+- **macOS**: `./orchard.sh` — Docker container (Ubuntu 22.04) with all tooling pre-installed
+- **Linux**: `./bw-opencode` — Bubblewrap sandbox
+- Git push/pull must be done on the host, not inside sandboxes

--- a/Dockerfile.orchard
+++ b/Dockerfile.orchard
@@ -294,7 +294,7 @@ fi
 # Copy Claude Code user config from the read-only staging mount.
 if [ -f /tmp/claude-host-config.json ]; then
     cp /tmp/claude-host-config.json /home/orchard/.claude.json
-    chmod u+rw /home/orchard/.claude.json
+    chmod 600 /home/orchard/.claude.json
 fi
 
 # Write OAuth credentials from macOS Keychain (passed via --env-file) to the

--- a/Dockerfile.orchard
+++ b/Dockerfile.orchard
@@ -303,6 +303,7 @@ fi
 CLAUDE_HOME="/home/orchard/.claude"
 if [ -n "${CLAUDE_CODE_KEYCHAIN_CREDS:-}" ]; then
     mkdir -p "$CLAUDE_HOME"
+    chmod 700 "$CLAUDE_HOME"
     echo "$CLAUDE_CODE_KEYCHAIN_CREDS" > "$CLAUDE_HOME/.credentials.json"
     chmod 600 "$CLAUDE_HOME/.credentials.json"
     # Don't leak the credentials into the process environment

--- a/Dockerfile.orchard
+++ b/Dockerfile.orchard
@@ -58,8 +58,8 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Install opencode and openspec
-RUN npm install -g opencode-ai@latest @fission-ai/openspec
+# Install opencode, openspec, and Claude Code
+RUN npm install -g opencode-ai@latest @fission-ai/openspec @anthropic-ai/claude-code
 
 # Build Fray JVMTI agent for linux-aarch64 (not published to Maven Central)
 # Then install it into the system Maven repo so the project can resolve it.
@@ -289,6 +289,29 @@ if [ -d "$OPENJML_DIR" ] && [ -d /opt/openjml-assets ]; then
 
     chmod -R u+rwX "$OPENJML_DIR"
     export OPENJML_SOLVERS="$OPENJML_DIR"
+fi
+
+# Copy Claude Code config from the read-only staging mount to writable paths.
+CLAUDE_HOME="/home/orchard/.claude"
+if [ -d /tmp/claude-host-config ]; then
+    mkdir -p "$CLAUDE_HOME"
+    cp -a /tmp/claude-host-config/. "$CLAUDE_HOME/"
+    chmod -R u+rwX "$CLAUDE_HOME"
+fi
+if [ -f /tmp/claude-host-config.json ]; then
+    cp /tmp/claude-host-config.json /home/orchard/.claude.json
+    chmod u+rw /home/orchard/.claude.json
+fi
+
+# Write OAuth credentials from macOS Keychain (passed via env var) to the
+# Linux credential file. On Linux, Claude Code reads ~/.claude/.credentials.json
+# instead of the macOS Keychain.
+if [ -n "${CLAUDE_CODE_KEYCHAIN_CREDS:-}" ]; then
+    mkdir -p "$CLAUDE_HOME"
+    echo "$CLAUDE_CODE_KEYCHAIN_CREDS" > "$CLAUDE_HOME/.credentials.json"
+    chmod 600 "$CLAUDE_HOME/.credentials.json"
+    # Don't leak the credentials into the process environment
+    unset CLAUDE_CODE_KEYCHAIN_CREDS
 fi
 
 # The Makefile uses `JHOME =` (not ?=), so env vars get ignored.

--- a/Dockerfile.orchard
+++ b/Dockerfile.orchard
@@ -291,21 +291,16 @@ if [ -d "$OPENJML_DIR" ] && [ -d /opt/openjml-assets ]; then
     export OPENJML_SOLVERS="$OPENJML_DIR"
 fi
 
-# Copy Claude Code config from the read-only staging mount to writable paths.
-CLAUDE_HOME="/home/orchard/.claude"
-if [ -d /tmp/claude-host-config ]; then
-    mkdir -p "$CLAUDE_HOME"
-    cp -a /tmp/claude-host-config/. "$CLAUDE_HOME/"
-    chmod -R u+rwX "$CLAUDE_HOME"
-fi
+# Copy Claude Code user config from the read-only staging mount.
 if [ -f /tmp/claude-host-config.json ]; then
     cp /tmp/claude-host-config.json /home/orchard/.claude.json
     chmod u+rw /home/orchard/.claude.json
 fi
 
-# Write OAuth credentials from macOS Keychain (passed via env var) to the
-# Linux credential file. On Linux, Claude Code reads ~/.claude/.credentials.json
-# instead of the macOS Keychain.
+# Write OAuth credentials from macOS Keychain (passed via --env-file) to the
+# Linux credential file. On Linux without a system keyring, Claude Code reads
+# ~/.claude/.credentials.json as a plaintext fallback.
+CLAUDE_HOME="/home/orchard/.claude"
 if [ -n "${CLAUDE_CODE_KEYCHAIN_CREDS:-}" ]; then
     mkdir -p "$CLAUDE_HOME"
     echo "$CLAUDE_CODE_KEYCHAIN_CREDS" > "$CLAUDE_HOME/.credentials.json"

--- a/orchard.sh
+++ b/orchard.sh
@@ -82,14 +82,23 @@ if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
     CLAUDE_ENV+=(-e "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}")
 fi
 
-# Extract Claude Code OAuth token from macOS Keychain and pass it to the container.
-# Claude Code stores OAuth credentials in the keychain under "Claude Code-credentials".
-# We extract the access token and pass it as ANTHROPIC_AUTH_TOKEN (bearer token).
+# Extract Claude Code OAuth credentials from macOS Keychain and pass them to the
+# container via a temp file (not a -e env var, which would be visible in docker inspect).
+# Claude Code stores its OAuth session in the keychain under "Claude Code-credentials".
+# The entrypoint writes the credentials to ~/.claude/.credentials.json (Linux fallback).
 # Authenticate on the host first: run `claude` and complete the OAuth flow.
-if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+# Note: OAuth tokens expire. Refreshed tokens are lost when the container exits,
+# but Claude Code will use the refresh token for the duration of the session.
+CREDS_ENV_FILE=""
+cleanup_creds() { [[ -n "$CREDS_ENV_FILE" ]] && rm -f "$CREDS_ENV_FILE"; }
+trap cleanup_creds EXIT
+
+if [[ -z "${ANTHROPIC_API_KEY:-}" ]] && command -v security &>/dev/null; then
     CLAUDE_CREDS_JSON=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null || true)
     if [[ -n "$CLAUDE_CREDS_JSON" ]]; then
-        CLAUDE_ENV+=(-e "CLAUDE_CODE_KEYCHAIN_CREDS=${CLAUDE_CREDS_JSON}")
+        CREDS_ENV_FILE=$(mktemp)
+        printf 'CLAUDE_CODE_KEYCHAIN_CREDS=%s\n' "$CLAUDE_CREDS_JSON" > "$CREDS_ENV_FILE"
+        chmod 600 "$CREDS_ENV_FILE"
         info "Extracted Claude Code OAuth credentials from macOS Keychain"
     else
         warn "No Claude Code credentials found in macOS Keychain."
@@ -97,15 +106,13 @@ if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
     fi
 fi
 
-# Mount Claude Code config files (settings, history, etc.) to a staging location.
-# The entrypoint copies them to writable paths so Claude Code can function.
-CLAUDE_AUTH_MOUNT=()
-if [[ -d "${HOME}/.claude" ]]; then
-    CLAUDE_AUTH_MOUNT=(-v "${HOME}/.claude:/tmp/claude-host-config:ro")
-    info "Mounting Claude Code config (read-only) from ~/.claude"
-fi
+# Mount Claude Code user config (.claude.json) to a staging location.
+# The entrypoint copies it to a writable path so Claude Code can function.
+# Only the top-level config is mounted — not ~/.claude/ (settings, history, etc.)
+# since credentials now come via the keychain injection above.
+CLAUDE_CONFIG_MOUNT=()
 if [[ -f "${HOME}/.claude.json" ]]; then
-    CLAUDE_AUTH_MOUNT+=(-v "${HOME}/.claude.json:/tmp/claude-host-config.json:ro")
+    CLAUDE_CONFIG_MOUNT=(-v "${HOME}/.claude.json:/tmp/claude-host-config.json:ro")
     info "Mounting Claude Code config from ~/.claude.json"
 fi
 
@@ -115,7 +122,8 @@ docker run \
     --name "$CONTAINER_NAME" \
     --hostname orchard \
     -v "${PROJECT_DIR}:/workspace" \
-    "${CLAUDE_AUTH_MOUNT[@]}" \
+    ${CLAUDE_CONFIG_MOUNT[@]+"${CLAUDE_CONFIG_MOUNT[@]}"} \
+    ${CREDS_ENV_FILE:+--env-file "$CREDS_ENV_FILE"} \
     --tmpfs /workspace/tooling/jdk-21.0.7+6:exec,uid=1000,gid=1000 \
     --tmpfs /workspace/tooling/openjml:exec,uid=1000,gid=1000 \
     -w /workspace \
@@ -123,6 +131,6 @@ docker run \
     --cap-drop ALL \
     --cap-add DAC_OVERRIDE \
     --cap-add FOWNER \
-    "${CLAUDE_ENV[@]}" \
+    ${CLAUDE_ENV[@]+"${CLAUDE_ENV[@]}"} \
     "$IMAGE_NAME" \
     "${@:-bash}"

--- a/orchard.sh
+++ b/orchard.sh
@@ -77,12 +77,45 @@ echo ""
 
 # The macOS tooling JDK can't run on Linux. We overlay it with a tmpfs
 # that the entrypoint populates with Linux JDK symlinks.
+CLAUDE_ENV=()
+if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+    CLAUDE_ENV+=(-e "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}")
+fi
+
+# Extract Claude Code OAuth token from macOS Keychain and pass it to the container.
+# Claude Code stores OAuth credentials in the keychain under "Claude Code-credentials".
+# We extract the access token and pass it as ANTHROPIC_AUTH_TOKEN (bearer token).
+# Authenticate on the host first: run `claude` and complete the OAuth flow.
+if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+    CLAUDE_CREDS_JSON=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null || true)
+    if [[ -n "$CLAUDE_CREDS_JSON" ]]; then
+        CLAUDE_ENV+=(-e "CLAUDE_CODE_KEYCHAIN_CREDS=${CLAUDE_CREDS_JSON}")
+        info "Extracted Claude Code OAuth credentials from macOS Keychain"
+    else
+        warn "No Claude Code credentials found in macOS Keychain."
+        warn "Run 'claude' on the host and complete login first, or set ANTHROPIC_API_KEY."
+    fi
+fi
+
+# Mount Claude Code config files (settings, history, etc.) to a staging location.
+# The entrypoint copies them to writable paths so Claude Code can function.
+CLAUDE_AUTH_MOUNT=()
+if [[ -d "${HOME}/.claude" ]]; then
+    CLAUDE_AUTH_MOUNT=(-v "${HOME}/.claude:/tmp/claude-host-config:ro")
+    info "Mounting Claude Code config (read-only) from ~/.claude"
+fi
+if [[ -f "${HOME}/.claude.json" ]]; then
+    CLAUDE_AUTH_MOUNT+=(-v "${HOME}/.claude.json:/tmp/claude-host-config.json:ro")
+    info "Mounting Claude Code config from ~/.claude.json"
+fi
+
 docker run \
     --rm \
     -it \
     --name "$CONTAINER_NAME" \
     --hostname orchard \
     -v "${PROJECT_DIR}:/workspace" \
+    "${CLAUDE_AUTH_MOUNT[@]}" \
     --tmpfs /workspace/tooling/jdk-21.0.7+6:exec,uid=1000,gid=1000 \
     --tmpfs /workspace/tooling/openjml:exec,uid=1000,gid=1000 \
     -w /workspace \
@@ -90,5 +123,6 @@ docker run \
     --cap-drop ALL \
     --cap-add DAC_OVERRIDE \
     --cap-add FOWNER \
+    "${CLAUDE_ENV[@]}" \
     "$IMAGE_NAME" \
     "${@:-bash}"


### PR DESCRIPTION
The flow:
  1. orchard.sh extracts the full OAuth credentials JSON from macOS Keychain NOTE: You'll need to enter your system password for this
  2. Passes it to the container as an env var
  3. The entrypoint writes it to ~/.claude/.credentials.json (where Linux Claude Code looks)
  4. Then unsets the env var so it's not visible to child processes