### PR TITLE
Add rlwrap installation to orchard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ recording.jfr
 # OS X
 .DS_Store
 
+# Orchard (generated, local-only)
+orchard.code-workspace
+
 # Jekyll / GitHub Pages
 docs/_site/
 docs/.jekyll-cache/

--- a/Dockerfile.orchard
+++ b/Dockerfile.orchard
@@ -225,6 +225,7 @@ RUN useradd -m -s /bin/bash orchard \
     && mkdir -p /home/orchard/.cache \
     && mkdir -p /home/orchard/.config \
     && mkdir -p /home/orchard/.m2 \
+    && mkdir -p /home/orchard/.claude \
     && cp -r /root/.m2/repository /home/orchard/.m2/repository \
     && chown -R orchard:orchard /home/orchard
 USER orchard

--- a/Dockerfile.orchard
+++ b/Dockerfile.orchard
@@ -226,8 +226,10 @@ RUN useradd -m -s /bin/bash orchard \
     && mkdir -p /home/orchard/.config \
     && mkdir -p /home/orchard/.m2 \
     && mkdir -p /home/orchard/.claude \
+    && mkdir -p /repos \
     && cp -r /root/.m2/repository /home/orchard/.m2/repository \
-    && chown -R orchard:orchard /home/orchard
+    && chown -R orchard:orchard /home/orchard \
+    && chown orchard:orchard /repos
 USER orchard
 WORKDIR /workspace
 

--- a/Dockerfile.orchard
+++ b/Dockerfile.orchard
@@ -237,7 +237,7 @@ WORKDIR /workspace
 COPY --chmod=755 <<'ENTRYPOINT' /usr/local/bin/orchard-entry.sh
 #!/bin/bash
 export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which java))))
-export PATH="${JAVA_HOME}/bin:${PATH}"
+export PATH="${JAVA_HOME}/bin:${HOME}/.local/bin:${PATH}"
 
 # Detect JDK 25 for Fray (the mvn wrapper references FRAY_JDK_HOME)
 for d in /usr/lib/jvm/temurin-25-*; do

--- a/Dockerfile.orchard
+++ b/Dockerfile.orchard
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     make \
     vim \
+    rlwrap \
     ca-certificates \
     gnupg \
     unzip \

--- a/orchard.sh
+++ b/orchard.sh
@@ -188,7 +188,7 @@ if [[ ${#EXTRA_CONTAINER_PATHS[@]} -gt 0 ]]; then
     {
         printf '{\n  "folders": [\n    { "path": "/workspace" }'
         for _cpath in "${EXTRA_CONTAINER_PATHS[@]}"; do
-            printf ',\n    { "path": "%s" }' "$_cpath"
+            printf ',\n    { "path": "/repos/%s" }' "$(basename "$_cpath")"
         done
         printf '\n  ]\n}\n'
     } > "$WORKSPACE_FILE"

--- a/orchard.sh
+++ b/orchard.sh
@@ -54,12 +54,20 @@ if [[ ! -f "$DOCKERFILE" ]]; then
     exit 1
 fi
 
-# Rebuild if image doesn't exist or Dockerfile is newer than image
+# Rebuild if image doesn't exist or Dockerfile is newer than image.
+# -nt can't compare a file against a Docker timestamp string, so we extract
+# epoch seconds from both sides and compare numerically.
 NEEDS_BUILD=false
 if ! docker image inspect "$IMAGE_NAME" &>/dev/null 2>&1; then
     NEEDS_BUILD=true
-elif [[ "$DOCKERFILE" -nt "$(docker image inspect "$IMAGE_NAME" --format '{{.Created}}' 2>/dev/null || echo '2000-01-01')" ]]; then
-    NEEDS_BUILD=true
+else
+    DOCKERFILE_MTIME=$(stat -f %m "$DOCKERFILE")
+    IMAGE_CREATED=$(docker image inspect "$IMAGE_NAME" --format '{{.Created}}' 2>/dev/null)
+    # Strip fractional seconds and timezone suffix (handles both "…Z" and "….nnnZ" forms)
+    IMAGE_MTIME=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${IMAGE_CREATED%%[.Z]*}" "+%s" 2>/dev/null || echo 0)
+    if [[ "$DOCKERFILE_MTIME" -gt "$IMAGE_MTIME" ]]; then
+        NEEDS_BUILD=true
+    fi
 fi
 
 if $NEEDS_BUILD; then

--- a/orchard.sh
+++ b/orchard.sh
@@ -138,6 +138,20 @@ if [[ -z "${OPENAI_API_KEY:-}" ]] && [[ -f "${HOME}/.codex/auth.json" ]]; then
     info "Mounting Codex auth from ~/.codex/auth.json"
 fi
 
+# ── Per-project persistent Claude volume ─────────────────────────────────────
+# Each PWD gets its own named volume so ~/.claude (chat history, settings) is
+# preserved across container sessions and compartmentalized per project.
+# Volume name: orchard-claude-<basename>-<8-char hash of full path>
+_vol_suffix=$(printf '%s' "$PROJECT_DIR" | md5 -q | cut -c1-8)
+CLAUDE_VOLUME="orchard-claude-$(basename "$PROJECT_DIR")-${_vol_suffix}"
+unset _vol_suffix
+if ! docker volume inspect "$CLAUDE_VOLUME" &>/dev/null 2>&1; then
+    docker volume create "$CLAUDE_VOLUME" > /dev/null
+    info "Created persistent Claude volume: ${CLAUDE_VOLUME}"
+else
+    info "Using existing Claude volume: ${CLAUDE_VOLUME}"
+fi
+
 # Extra bind mounts injected by callers (e.g. orchardw.sh).
 # ORCHARD_EXTRA_MOUNTS: newline-separated list of "host:container" path pairs.
 EXTRA_MOUNTS=()
@@ -159,6 +173,7 @@ docker run \
     ${CLAUDE_CONFIG_MOUNT[@]+"${CLAUDE_CONFIG_MOUNT[@]}"} \
     ${CODEX_AUTH_MOUNT[@]+"${CODEX_AUTH_MOUNT[@]}"} \
     ${EXTRA_MOUNTS[@]+"${EXTRA_MOUNTS[@]}"} \
+    -v "${CLAUDE_VOLUME}:/home/orchard/.claude" \
     ${CREDS_ENV_FILE:+--env-file "$CREDS_ENV_FILE"} \
     --tmpfs /workspace/tooling/jdk-21.0.7+6:exec,uid=1000,gid=1000 \
     --tmpfs /workspace/tooling/openjml:exec,uid=1000,gid=1000 \

--- a/orchard.sh
+++ b/orchard.sh
@@ -186,13 +186,9 @@ fi
 WORKSPACE_FILE="${PROJECT_DIR}/orchard.code-workspace"
 if [[ ${#EXTRA_CONTAINER_PATHS[@]} -gt 0 ]]; then
     {
-        printf '{\n  "folders": [\n    { "path": "/workspace" }'
-        for _cpath in "${EXTRA_CONTAINER_PATHS[@]}"; do
-            printf ',\n    { "path": "/repos/%s" }' "$(basename "$_cpath")"
-        done
-        printf '\n  ]\n}\n'
+        printf '{\n  "folders": [\n    { "path": "/workspace" },\n    { "path": "/repos" }\n  ]\n}\n'
     } > "$WORKSPACE_FILE"
-    info "Generated orchard.code-workspace with ${#EXTRA_CONTAINER_PATHS[@]} extra repo(s)"
+    info "Generated orchard.code-workspace with /repos root"
     # Keep the generated file out of git
     _GITIGNORE="${PROJECT_DIR}/.gitignore"
     if [[ -f "$_GITIGNORE" ]] && ! grep -qxF 'orchard.code-workspace' "$_GITIGNORE"; then
@@ -202,7 +198,6 @@ if [[ ${#EXTRA_CONTAINER_PATHS[@]} -gt 0 ]]; then
         echo 'orchard.code-workspace' > "$_GITIGNORE"
     fi
     unset _GITIGNORE
-    unset _cpath
 else
     [[ -f "$WORKSPACE_FILE" ]] && rm -f "$WORKSPACE_FILE"
 fi

--- a/orchard.sh
+++ b/orchard.sh
@@ -138,6 +138,18 @@ if [[ -z "${OPENAI_API_KEY:-}" ]] && [[ -f "${HOME}/.codex/auth.json" ]]; then
     info "Mounting Codex auth from ~/.codex/auth.json"
 fi
 
+# Extra bind mounts injected by callers (e.g. orchardw.sh).
+# ORCHARD_EXTRA_MOUNTS: newline-separated list of "host:container" path pairs.
+EXTRA_MOUNTS=()
+if [[ -n "${ORCHARD_EXTRA_MOUNTS:-}" ]]; then
+    while IFS= read -r _pair; do
+        [[ -z "$_pair" ]] && continue
+        _host="${_pair%%:*}"
+        _container="${_pair#*:}"
+        [[ -d "$_host" ]] && EXTRA_MOUNTS+=(-v "${_host}:${_container}")
+    done <<< "$ORCHARD_EXTRA_MOUNTS"
+fi
+
 docker run \
     --rm \
     -it \
@@ -146,6 +158,7 @@ docker run \
     -v "${PROJECT_DIR}:/workspace" \
     ${CLAUDE_CONFIG_MOUNT[@]+"${CLAUDE_CONFIG_MOUNT[@]}"} \
     ${CODEX_AUTH_MOUNT[@]+"${CODEX_AUTH_MOUNT[@]}"} \
+    ${EXTRA_MOUNTS[@]+"${EXTRA_MOUNTS[@]}"} \
     ${CREDS_ENV_FILE:+--env-file "$CREDS_ENV_FILE"} \
     --tmpfs /workspace/tooling/jdk-21.0.7+6:exec,uid=1000,gid=1000 \
     --tmpfs /workspace/tooling/openjml:exec,uid=1000,gid=1000 \

--- a/orchard.sh
+++ b/orchard.sh
@@ -94,6 +94,9 @@ fi
 if [[ -n "${OPENAI_API_KEY:-}" ]]; then
     AGENT_ENV+=(-e "OPENAI_API_KEY=${OPENAI_API_KEY}")
 fi
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    AGENT_ENV+=(-e "GITHUB_TOKEN=${GITHUB_TOKEN}")
+fi
 
 # Extract Claude Code OAuth credentials from macOS Keychain and pass them to the
 # container via a temp file (not a -e env var, which would be visible in docker inspect).

--- a/orchard.sh
+++ b/orchard.sh
@@ -147,6 +147,14 @@ CLAUDE_VOLUME="orchard-claude-$(basename "$PROJECT_DIR")-${_vol_suffix}"
 unset _vol_suffix
 if ! docker volume inspect "$CLAUDE_VOLUME" &>/dev/null 2>&1; then
     docker volume create "$CLAUDE_VOLUME" > /dev/null
+    # Docker creates new volume mount points as root:root. Fix ownership so the
+    # orchard user can write into it without needing elevated capabilities.
+    docker run --rm \
+        -v "${CLAUDE_VOLUME}:/home/orchard/.claude" \
+        --user root \
+        --entrypoint "" \
+        "$IMAGE_NAME" \
+        chown orchard:orchard /home/orchard/.claude
     info "Created persistent Claude volume: ${CLAUDE_VOLUME}"
 else
     info "Using existing Claude volume: ${CLAUDE_VOLUME}"

--- a/orchard.sh
+++ b/orchard.sh
@@ -161,16 +161,17 @@ else
 fi
 
 # Extra bind mounts injected by callers (e.g. orchardw.sh).
-# ORCHARD_EXTRA_MOUNTS: newline-separated list of host paths (or "host:ignored"
-# pairs for backwards compat). Each repo is mounted at /repos/<basename>.
+# ORCHARD_EXTRA_MOUNTS: newline-separated list of "host:container" pairs.
+# Bare host paths (no colon) fall back to /repos/<basename>.
 EXTRA_MOUNTS=()
 EXTRA_CONTAINER_PATHS=()
 if [[ -n "${ORCHARD_EXTRA_MOUNTS:-}" ]]; then
     while IFS= read -r _pair; do
         [[ -z "$_pair" ]] && continue
         _host="${_pair%%:*}"
+        _container="${_pair#*:}"
+        [[ "$_container" == "$_pair" ]] && _container="/repos/$(basename "$_host")"
         if [[ -d "$_host" ]]; then
-            _container="/repos/$(basename "$_host")"
             EXTRA_MOUNTS+=(-v "${_host}:${_container}")
             EXTRA_CONTAINER_PATHS+=("$_container")
         fi

--- a/orchard.sh
+++ b/orchard.sh
@@ -191,5 +191,7 @@ docker run \
     --cap-add DAC_OVERRIDE \
     --cap-add FOWNER \
     ${AGENT_ENV[@]+"${AGENT_ENV[@]}"} \
+    -e "ORCHARD_PROJECT=$(basename "$PROJECT_DIR")" \
+    -e 'PROMPT_COMMAND=PS1="(\[\033[1;32m\]\u@\h\[\033[0m\])[\[\033[1;34m\]${ORCHARD_PROJECT}\[\033[0m\]] \w\$ "' \
     "$IMAGE_NAME" \
     "${@:-bash}"

--- a/orchard.sh
+++ b/orchard.sh
@@ -161,16 +161,48 @@ else
 fi
 
 # Extra bind mounts injected by callers (e.g. orchardw.sh).
-# ORCHARD_EXTRA_MOUNTS: newline-separated list of "host:container" path pairs.
+# ORCHARD_EXTRA_MOUNTS: newline-separated list of host paths (or "host:ignored"
+# pairs for backwards compat). Each repo is mounted at /repos/<basename>.
 EXTRA_MOUNTS=()
+EXTRA_CONTAINER_PATHS=()
 if [[ -n "${ORCHARD_EXTRA_MOUNTS:-}" ]]; then
     while IFS= read -r _pair; do
         [[ -z "$_pair" ]] && continue
         _host="${_pair%%:*}"
-        _container="${_pair#*:}"
-        [[ -d "$_host" ]] && EXTRA_MOUNTS+=(-v "${_host}:${_container}")
+        if [[ -d "$_host" ]]; then
+            _container="/repos/$(basename "$_host")"
+            EXTRA_MOUNTS+=(-v "${_host}:${_container}")
+            EXTRA_CONTAINER_PATHS+=("$_container")
+        fi
     done <<< "$ORCHARD_EXTRA_MOUNTS"
 fi
+
+# Generate orchard.code-workspace when extra repos are mounted so VS Code
+# opens all roots automatically via "Dev Containers: Attach to Running Container".
+WORKSPACE_FILE="${PROJECT_DIR}/orchard.code-workspace"
+if [[ ${#EXTRA_CONTAINER_PATHS[@]} -gt 0 ]]; then
+    {
+        printf '{\n  "folders": [\n    { "path": "/workspace" }'
+        for _cpath in "${EXTRA_CONTAINER_PATHS[@]}"; do
+            printf ',\n    { "path": "%s" }' "$_cpath"
+        done
+        printf '\n  ]\n}\n'
+    } > "$WORKSPACE_FILE"
+    info "Generated orchard.code-workspace with ${#EXTRA_CONTAINER_PATHS[@]} extra repo(s)"
+    # Keep the generated file out of git
+    _GITIGNORE="${PROJECT_DIR}/.gitignore"
+    if [[ -f "$_GITIGNORE" ]] && ! grep -qxF 'orchard.code-workspace' "$_GITIGNORE"; then
+        echo 'orchard.code-workspace' >> "$_GITIGNORE"
+        info "Added orchard.code-workspace to .gitignore"
+    elif [[ ! -f "$_GITIGNORE" ]]; then
+        echo 'orchard.code-workspace' > "$_GITIGNORE"
+    fi
+    unset _GITIGNORE
+    unset _cpath
+else
+    [[ -f "$WORKSPACE_FILE" ]] && rm -f "$WORKSPACE_FILE"
+fi
+unset WORKSPACE_FILE
 
 docker run \
     --rm \


### PR DESCRIPTION
## Summary

- **Add rlwrap** — installs `rlwrap` in the container image for readline-style
  history in interactive CLIs (JShell, Clojure REPL, etc.)
- **Persist `~/.claude` per project** — each project directory gets its own
  named Docker volume (`orchard-claude-<name>-<hash>`) mounted at `~/.claude`,
  so Claude session history and settings survive container restarts and stay
  compartmentalized per project; volume ownership is fixed on creation so the
  `orchard` user can write without elevated caps
- **Accept extra bind mounts with auto VS Code workspace** — callers set
  `ORCHARD_EXTRA_MOUNTS` (newline-separated host paths) to inject additional
  repos; each is mounted at `/repos/<basename>` (provisioned in
  `Dockerfile.orchard` with `orchard` ownership) and `orchard.sh`
  auto-generates `orchard.code-workspace` listing all roots so VS Code's
  "Attach to Running Container" opens everything at once; when no extra mounts
  are present any stale workspace file is removed; `orchard.code-workspace` is
  added to `.gitignore` both statically (committed) and at runtime as a safety
  net
- **Show project name in shell prompt** — injects `ORCHARD_PROJECT` and
  `PROMPT_COMMAND` so the container prompt identifies which project you're
  working in
- **Fix `NEEDS_BUILD` detection** — replaced the broken `-nt` comparison
  (which compared a file path against a Docker timestamp string) with numeric
  epoch comparison via `stat` + `date -j`, so the image is only rebuilt when
  the Dockerfile actually changed

## Test plan

- [x] `./orchard.sh` on a fresh checkout rebuilds the image; subsequent runs skip the build
- [x] Modifying `Dockerfile.orchard` triggers a rebuild; unmodified does not
- [x] `~/.claude` inside the container survives `exit` + re-enter; a second project gets a separate volume
- [x] Setting `ORCHARD_EXTRA_MOUNTS="/path/to/other-repo"` mounts it at `/repos/other-repo` inside the container
- [x] With extra mounts set, `orchard.code-workspace` is generated at project root and `orchard.code-workspace` appears in `.gitignore`
- [x] Without extra mounts, any stale `orchard.code-workspace` is removed
- [x] Shell prompt inside container shows `[<project-name>]`
- [x] `rlwrap --version` works inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)
